### PR TITLE
Add ServicesConfigurations Table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.200
+          dotnet-version: 6.0.100
 
       - name: Setup NuGet.exe
         uses: NuGet/setup-nuget@v1.0.5

--- a/Common.Configurations.targets
+++ b/Common.Configurations.targets
@@ -2,7 +2,7 @@
 
 <Project>
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>LT.DigitalOffice.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>LT.DigitalOffice.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>
@@ -26,10 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="($(AssemblyName.Contains('.Provider')) Or $(AssemblyName.Contains('.Models.Db'))) And $(AssemblyName.Contains('.UnitTests')) != 'true'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(AssemblyName.Contains('.UnitTests')) != 'true'">

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
 WORKDIR /app
 
 COPY . ./
@@ -7,7 +7,7 @@ RUN dotnet restore -s https://api.nuget.org/v3/index.json
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
 WORKDIR /app
 COPY --from=build /app/out .
 EXPOSE 80

--- a/src/AdminService.Data.Provider.MsSql.Ef/AdminService.Data.Provider.MsSql.Ef.csproj
+++ b/src/AdminService.Data.Provider.MsSql.Ef/AdminService.Data.Provider.MsSql.Ef.csproj
@@ -3,10 +3,6 @@
   <Import Project="$(ProjectDir)..\..\Common.Configurations.targets" />
 
   <ItemGroup>
-    <Folder Include="Migrations\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\AdminService.Data.Provider\AdminService.Data.Provider.csproj" />
     <ProjectReference Include="..\AdminService.Models.Db\AdminService.Models.Db.csproj" />
   </ItemGroup>

--- a/src/AdminService.Data.Provider.MsSql.Ef/AdminServiceDbContext.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/AdminServiceDbContext.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
+﻿using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using LT.DigitalOffice.AdminService.Models.Db;
 using Microsoft.EntityFrameworkCore;
 
 namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef
@@ -10,6 +12,10 @@ namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef
     : base(options)
     {
     }
+
+    public IQueryable<DbServiceConfiguration> ServicesConfigurations => _servicesConfigurations.AsQueryable();
+
+    private DbSet<DbServiceConfiguration> _servicesConfigurations { get; set; }
 
     // Fluent API is written here.
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/AdminService.Data.Provider.MsSql.Ef/AdminServiceDbContext.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/AdminServiceDbContext.cs
@@ -8,14 +8,14 @@ namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef
 {
   public class AdminServiceDbContext : DbContext, IDataProvider
   {
+    private DbSet<DbServiceConfiguration> _servicesConfigurations { get; set; }
+
+    public IQueryable<DbServiceConfiguration> ServicesConfigurations => _servicesConfigurations.AsQueryable();
+
     public AdminServiceDbContext(DbContextOptions<AdminServiceDbContext> options)
     : base(options)
     {
     }
-
-    public IQueryable<DbServiceConfiguration> ServicesConfigurations => _servicesConfigurations.AsQueryable();
-
-    private DbSet<DbServiceConfiguration> _servicesConfigurations { get; set; }
 
     // Fluent API is written here.
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/AdminService.Data.Provider.MsSql.Ef/Configuration/DbServiceConfigurationConfiguration.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/Configuration/DbServiceConfigurationConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using LT.DigitalOffice.AdminService.Models.Db;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef.Configuration
+{
+  public class DbServiceConfigurationConfiguration : IEntityTypeConfiguration<DbServiceConfiguration>
+  {
+    public void Configure(EntityTypeBuilder<DbServiceConfiguration> builder)
+    {
+      builder
+        .ToTable(DbServiceConfiguration.TableName);
+
+      builder
+        .HasKey(sc => sc.Id);
+
+      builder
+        .Property(sc => sc.ServiceName)
+        .IsRequired();
+
+      builder
+        .Property(sc => sc.IsActive)
+        .IsRequired();
+    }
+  }
+}

--- a/src/AdminService.Data.Provider.MsSql.Ef/Configuration/DbServiceConfigurationConfiguration.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/Configuration/DbServiceConfigurationConfiguration.cs
@@ -17,10 +17,6 @@ namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef.Configuration
       builder
         .Property(sc => sc.ServiceName)
         .IsRequired();
-
-      builder
-        .Property(sc => sc.IsActive)
-        .IsRequired();
     }
   }
 }

--- a/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
@@ -245,19 +245,6 @@ namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef.Migrations
           "uniqueidentifier",
           "datetime2"
         },
-        values: new object[] { Guid.NewGuid(), "AuthService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
         values: new object[] { Guid.NewGuid(), "AchievementService", true, null, null });
     }
 

--- a/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using LT.DigitalOffice.AdminService.Models.Db;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef.Migrations
+{
+  [DbContext(typeof(AdminServiceDbContext))]
+  [Migration("_20211123223000_InitialTable")]
+  public class InitialTable : Migration
+  {
+    protected override void Up(MigrationBuilder builder)
+    {
+      builder.CreateTable(
+        name: DbServiceConfiguration.TableName,
+        columns: table => new
+        {
+          Id = table.Column<Guid>(nullable: false),
+          ServiceName = table.Column<string>(nullable: false),
+          IsActive = table.Column<bool>(nullable: false),
+          ModifiedBy = table.Column<Guid>(nullable: true),
+          ModifiedAtUtc = table.Column<DateTime>(nullable: true)
+        },
+        constraints: table =>
+        {
+          table.PrimaryKey($"PK_{DbServiceConfiguration.TableName}", x => x.Id);
+        });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "TimeService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "TaskService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "StreamService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "SearchService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "RightsService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "ProjectService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "PositionService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "OfficeService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "NewsService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "MessageService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "ImageService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "HistoryService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "FileService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "EducationService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "DepartmentService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "CompanyService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "AuthService", true, null, null });
+
+      builder.InsertData(
+        table: DbServiceConfiguration.TableName,
+        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
+        columnTypes: new string[]
+        {
+          "uniqueidentifier",
+          "nvarchar(max)",
+          "bit",
+          "uniqueidentifier",
+          "datetime2"
+        },
+        values: new object[] { Guid.NewGuid(), "AchievementService", true, null, null });
+    }
+
+    protected override void Down(MigrationBuilder builder)
+    {
+      builder.DropTable(
+        name: DbServiceConfiguration.TableName);
+    }
+  }
+}

--- a/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
+++ b/src/AdminService.Data.Provider.MsSql.Ef/Migrations/20211123223000_InitialTable.cs
@@ -37,215 +37,25 @@ namespace LT.DigitalOffice.AdminService.Data.Provider.MsSql.Ef.Migrations
           "uniqueidentifier",
           "datetime2"
         },
-        values: new object[] { Guid.NewGuid(), "TimeService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "TaskService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "StreamService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "SearchService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "RightsService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "ProjectService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "PositionService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "OfficeService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "NewsService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "MessageService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "ImageService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "HistoryService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "FileService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "EducationService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "DepartmentService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "CompanyService", true, null, null });
-
-      builder.InsertData(
-        table: DbServiceConfiguration.TableName,
-        columns: new[] { "Id", "ServiceName", "IsActive", "ModifiedBy", "ModifiedAtUtc" },
-        columnTypes: new string[]
-        {
-          "uniqueidentifier",
-          "nvarchar(max)",
-          "bit",
-          "uniqueidentifier",
-          "datetime2"
-        },
-        values: new object[] { Guid.NewGuid(), "AchievementService", true, null, null });
+        values: new object[,] {
+          { Guid.NewGuid(), "TimeService", true, null, null },
+          { Guid.NewGuid(), "TaskService", true, null, null },
+          { Guid.NewGuid(), "StreamService", true, null, null },
+          { Guid.NewGuid(), "SearchService", true, null, null },
+          { Guid.NewGuid(), "RightsService", true, null, null },
+          { Guid.NewGuid(), "ProjectService", true, null, null },
+          { Guid.NewGuid(), "PositionService", true, null, null },
+          { Guid.NewGuid(), "OfficeService", true, null, null },
+          { Guid.NewGuid(), "NewsService", true, null, null },
+          { Guid.NewGuid(), "MessageService", true, null, null },
+          { Guid.NewGuid(), "ImageService", true, null, null },
+          { Guid.NewGuid(), "HistoryService", true, null, null },
+          { Guid.NewGuid(), "FileService", true, null, null },
+          { Guid.NewGuid(), "EducationService", true, null, null },
+          { Guid.NewGuid(), "DepartmentService", true, null, null },
+          { Guid.NewGuid(), "CompanyService", true, null, null },
+          { Guid.NewGuid(), "AchievementService", true, null, null }
+        });
     }
 
     protected override void Down(MigrationBuilder builder)

--- a/src/AdminService.Data.Provider/IDataProvider.cs
+++ b/src/AdminService.Data.Provider/IDataProvider.cs
@@ -1,4 +1,6 @@
-﻿using LT.DigitalOffice.Kernel.Attributes;
+﻿using System.Linq;
+using LT.DigitalOffice.AdminService.Models.Db;
+using LT.DigitalOffice.Kernel.Attributes;
 using LT.DigitalOffice.Kernel.Database;
 using LT.DigitalOffice.Kernel.Enums;
 
@@ -7,5 +9,6 @@ namespace LT.DigitalOffice.AdminService.Data.Provider
   [AutoInject(InjectType.Scoped)]
   public interface IDataProvider : IBaseDataProvider
   {
+    IQueryable<DbServiceConfiguration> ServicesConfigurations { get; }
   }
 }

--- a/src/AdminService.Data/AdminService.Data.csproj
+++ b/src/AdminService.Data/AdminService.Data.csproj
@@ -3,10 +3,6 @@
   <Import Project="$(ProjectDir)..\..\Common.Configurations.targets" />
 
   <ItemGroup>
-    <Folder Include="Interfaces\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\AdminService.Data.Provider.MsSql.Ef\AdminService.Data.Provider.MsSql.Ef.csproj" />
     <ProjectReference Include="..\AdminService.Data.Provider\AdminService.Data.Provider.csproj" />
     <ProjectReference Include="..\AdminService.Models.Db\AdminService.Models.Db.csproj" />

--- a/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
+++ b/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace LT.DigitalOffice.AdminService.Data.Interfaces
 {
-    public class IServiceConfigurationRepository
+    public interface IServiceConfigurationRepository
     {
     }
 }

--- a/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
+++ b/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LT.DigitalOffice.AdminService.Data.Interfaces
+{
+    public class IServiceConfigurationRepository
+    {
+    }
+}

--- a/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
+++ b/src/AdminService.Data/Interfaces/IServiceConfigurationRepository.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace LT.DigitalOffice.AdminService.Data.Interfaces
+﻿namespace LT.DigitalOffice.AdminService.Data.Interfaces
 {
-    public interface IServiceConfigurationRepository
-    {
-    }
+  public interface IServiceConfigurationRepository
+  {
+  }
 }

--- a/src/AdminService.Data/ServiceConfigurationRepository.cs
+++ b/src/AdminService.Data/ServiceConfigurationRepository.cs
@@ -1,0 +1,8 @@
+﻿using LT.DigitalOffice.AdminService.Data.Interfaces;
+
+namespace LT.DigitalOffice.AdminService.Data
+{
+  public class ServiceConfigurationRepository : IServiceConfigurationRepository
+  {
+  }
+}

--- a/src/AdminService.Models.Db/DbServiceConfiguration.cs
+++ b/src/AdminService.Models.Db/DbServiceConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace LT.DigitalOffice.AdminService.Models.Db
+{
+  public class DbServiceConfiguration
+  {
+    public const string TableName = "ServicesConfigurations";
+
+    public Guid Id { get; set; }
+    public string ServiceName { get; set; }
+    public bool IsActive { get; set; }
+    public Guid? ModifiedBy { get; set; }
+    public DateTime? ModifiedAtUtc { get; set; }
+  }
+}

--- a/src/AdminService/AdminService.csproj
+++ b/src/AdminService/AdminService.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="5.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />


### PR DESCRIPTION
http://outsourcing.nat.tepkom.ru:20080/redmine/issues/941
- add Db model DbServiceConfiguration
- add directory  AdminService.Data.Provider.MsSql.Ef/Configuration and tune fluentApi
- update AdminServiceDbContext and IDataProvider
- create migration to add ServicesConfigurations table and add entries for all services (except User, Email, Admin, Auth)
- add empty IServiceConfigurationRepository and ServiceConfigurationRepository